### PR TITLE
rbs subtract の引数から rbs/handwritten を削除する

### DIFF
--- a/rbs.rake
+++ b/rbs.rake
@@ -27,7 +27,7 @@ namespace :rbs do
     subtrahends = Rails.root.glob('sig/*')
       .reject { |path| path == prototype_path || path == rbs_rails_path }
       .map { |path| "--subtrahend=#{path}" }
-    sh 'rbs', 'subtract', '--write', 'sig/prototype', 'sig/rbs_rails', 'sig/handwritten', *subtrahends
+    sh 'rbs', 'subtract', '--write', 'sig/prototype', 'sig/rbs_rails', *subtrahends
   end
 
   task :validate do


### PR DESCRIPTION
rbs/handwritten ディレクトリは --subtrahends オプションとして指定するため、引数には指定しない。 (引数に指定すると、手書きで書いた型定義が空にされてしまうため、現在の指定は不適切)

Twitter で質問させていただいた件の修正です。
https://twitter.com/tk0miya/status/1659513540200534019